### PR TITLE
automates words.md -> index.html with github workflow

### DIFF
--- a/.github/workflows/build-index-with-words.yml
+++ b/.github/workflows/build-index-with-words.yml
@@ -1,0 +1,30 @@
+# This workflow will compile words/words.md to words/words.html. 
+# The content of words/words.html then replaces everything between 
+# the article tags in index.html. 
+# Any resulting changes will be committed and pushed to master.
+
+name: "Build index.html with words.md"
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Get the current source from master
+        uses: actions/checkout@master
+      - name: Convert markdown to html
+        uses: docker://pandoc/core:2.9 # use a docker image that has pandoc pre-installed
+        with:
+          args: "--from markdown_strict+footnotes words/words.md -o words/words.html"
+      - name: Merge html files
+        run: |
+          perl -0777pi -e 's/(?<=<article>)(\n?).*(?=<\/article>)/`printf "\n" & cat words\/words.html`/gse' index.html
+      - name: Commit and push changes if files have changed
+        uses: stefanzweifel/git-auto-commit-action@v4.1.6
+        with:
+          commit_message: Update index.html from words.md
+          commit_user_name: GitHub Action
+          commit_user_email: action@github.com


### PR DESCRIPTION
Already in use in the German translation: https://github.com/TQueV/
Based on the original idea with a split index.html file in the Italian translation: https://github.com/harisont/covid-19

The workflow will:
1. checkout master
2. convert md to html with pandoc
3. merge html files by replacing everything between the article tags in the index.html with the content of the words.html
4. commit changes if any were made and push back to master