### PR TITLE
Serbian translation, tiny edit for sake of consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 		<li><a href='https://leonardoalcantara.github.io/covid-19-pt-br/'>Português</a></li>
 		<li><a href='https://tquev.github.io/covid-19/'>Deutsch</a></li>
 		<li><a href='https://jusplathemus.github.io/covid-19/'>Magyar</a></li>
-		<li><a href='https://saskaaloric.github.io/covid-19/'>српски језик</a></li>
+		<li><a href='https://saskaaloric.github.io/covid-19/'>Srpski</a></li>
 		<li><a href='https://asherbarak.github.io/covid-19/'>עברית</a></li>
 		<li><a href='https://benbennben.github.io/covid-19/'>한국어</a></li>
 		<li><a href='https://eed3si9n.github.io/covid-19/'>日本語</a></li>


### PR DESCRIPTION
Proposed edit:
"српски језик" > "Srpski"
As the Serbian translation is done in Latin, not the Cyrillic alphabet (we use both transcriptions). Capitalisation is just for the consistency with other languages. 

Thanks
