### PR TITLE
Malayalam translation

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 		<li><a href='https://tquev.github.io/covid-19/'>Deutsch</a></li>
 		<li><a href='https://harisont.github.io/covid-19/'>Italiano</a></li>
 		<li><a href='https://jusplathemus.github.io/covid-19/'>Magyar</a></li>
+		<li><a href='https://covid19-next.coddk.org/'>മലയാളം</a></li>
 		<li><a href='https://dcz-self.github.io/covid-19/'>Polski</a></li>
 		<li><a href='https://saskaaloric.github.io/covid-19/'>Srpski</a></li>
 		<li><a href='https://asherbarak.github.io/covid-19/'>עברית</a></li>


### PR DESCRIPTION
Added Malayalam (മലയാളം) translation. Malayalam is the language of Kerala, a south Indian state.
This translation is prepared by CODD-K (Collective for Open Data Distribution - Kerala) as part of its https://covid19kerala.info/ project. 

Translation Language : Malayalam (മലയാളം)
URL : https://covid19-next.coddk.org/

Translation Repository : https://github.com/CODD-K/covid-19